### PR TITLE
[HADOOP-17912] Call destroy from input/output streams and refactor EncryptionAdapter 

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/EncryptionContextProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/EncryptionContextProvider.java
@@ -40,7 +40,7 @@ public interface EncryptionContextProvider extends Destroyable {
    * Fetch encryption context for a given path
    *
    * @param path file path from filesystem root
-   * @return encryptionContext string
+   * @return encryptionContext key
    * @throws IOException error in fetching encryption context
    */
   ABFSKey getEncryptionContext(String path) throws IOException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/security/EncryptionAdapter.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/security/EncryptionAdapter.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs.security;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
+import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
 import org.apache.hadoop.util.Preconditions;
@@ -75,7 +76,7 @@ public class EncryptionAdapter implements Destroyable {
     return getBase64EncodedString(encryptionContext.getEncoded());
   }
 
-  public void destroy() {
+  public void destroy() throws DestroyFailedException {
     if (encryptionContext != null) encryptionContext.destroy();
     if (encryptionKey != null) encryptionKey.destroy();
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -36,9 +35,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.fs.azurebfs.security.ABFSKey;
 import org.apache.hadoop.fs.store.LogExactlyOnce;
-import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore.Permissions;
 import org.apache.hadoop.fs.azurebfs.extensions.EncryptionContextProvider;
@@ -72,7 +69,6 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 
-import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -284,7 +280,7 @@ public class AbfsClient implements Closeable {
     if (encryptionAdapterCreated && encryptionAdapter != null) {
       try {
         encryptionAdapter.destroy();
-      } catch (Exception e) {
+      } catch (DestroyFailedException e) {
         throw new IOException(
           "Could not destroy encryptionContext: " + e.getMessage());
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -46,8 +46,6 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
-import javax.security.auth.DestroyFailedException;
-
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.fs.statistics.IOStatisticsSource;
 
+import javax.security.auth.DestroyFailedException;
+
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -701,7 +703,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     closed = true;
     try {
       if (encryptionAdapter != null) encryptionAdapter.destroy();
-    } catch (Exception e) {
+    } catch (DestroyFailedException e) {
       throw new IOException(
           "Could not destroy encryptionContext: " + e.getMessage());
     } finally {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -701,6 +701,7 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
   public synchronized void close() throws IOException {
     LOG.debug("Closing {}", this);
     closed = true;
+    ReadBufferManager.getBufferManager().purgeBuffersForStream(this);
     try {
       if (encryptionAdapter != null) encryptionAdapter.destroy();
     } catch (DestroyFailedException e) {
@@ -708,7 +709,6 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
           "Could not destroy encryptionContext: " + e.getMessage());
     } finally {
         buffer = null; // de-reference the buffer so it can be GC'ed sooner
-        ReadBufferManager.getBufferManager().purgeBuffersForStream(this);
       }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Syncable;
 
+import javax.security.auth.DestroyFailedException;
+
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.STREAM_ID_LEN;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsErrors.ERR_WRITE_WITHOUT_LEASE;
 import static org.apache.hadoop.fs.impl.StoreImplementationUtils.isProbeForSyncable;
@@ -499,7 +501,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
     } finally {
       try {
         if (encryptionAdapter != null) encryptionAdapter.destroy();
-      } catch (Exception e) {
+      } catch (DestroyFailedException e) {
         throw new IOException(
                 "Could not destroy encryptionContext: " + e.getMessage());
       } finally {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -497,17 +497,24 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
       // See HADOOP-16785
       throw wrapException(path, e.getMessage(), e);
     } finally {
-      if (hasLease()) {
-        lease.free();
-        lease = null;
-      }
-      lastError = new IOException(FSExceptionMessages.STREAM_IS_CLOSED);
-      buffer = null;
-      bufferIndex = 0;
-      closed = true;
-      writeOperations.clear();
-      if (hasActiveBlock()) {
-        clearActiveBlock();
+      try {
+        if (encryptionAdapter != null) encryptionAdapter.destroy();
+      } catch (Exception e) {
+        throw new IOException(
+                "Could not destroy encryptionContext: " + e.getMessage());
+      } finally {
+        if (hasLease()) {
+          lease.free();
+          lease = null;
+        }
+        lastError = new IOException(FSExceptionMessages.STREAM_IS_CLOSED);
+        buffer = null;
+        bufferIndex = 0;
+        closed = true;
+        writeOperations.clear();
+        if (hasActiveBlock()) {
+          clearActiveBlock();
+        }
       }
     }
     LOG.debug("Closing AbfsOutputStream : {}", this);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockEncryptionContextProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/extensions/MockEncryptionContextProvider.java
@@ -47,9 +47,9 @@ public class MockEncryptionContextProvider implements EncryptionContextProvider 
     pathToContextMap.put(path, newContext);
     byte[] newKey = new byte[ENCRYPTION_KEY_LEN];
     new Random().nextBytes(newKey);
-    ABFSKey key = new ABFSKey(newKey);
+    ABFSKey key = new MockABFSKey(newKey);
     contextToKeyMap.put(newContext, key);
-    return new ABFSKey(newContext.getBytes(StandardCharsets.UTF_8));
+    return new MockABFSKey(newContext.getBytes(StandardCharsets.UTF_8));
   }
 
   @Override
@@ -71,31 +71,13 @@ public class MockEncryptionContextProvider implements EncryptionContextProvider 
     contextToKeyMap = null;
   }
 
-  class Key implements SecretKey {
-
-    private final byte[] key;
-
-    Key(byte[] secret) {
-      key = secret;
-    }
-    @Override
-    public String getAlgorithm() {
-      return null;
-    }
-
-    @Override
-    public String getFormat() {
-      return null;
-    }
-
-    @Override
-    public byte[] getEncoded() {
-      return key;
+  class MockABFSKey extends ABFSKey {
+    public MockABFSKey(byte[] bytes) {
+      super(bytes);
     }
 
     @Override
     public void destroy() {
-      Arrays.fill(key, (byte) 0);
     }
   }
 

--- a/hadoop-tools/pom.xml
+++ b/hadoop-tools/pom.xml
@@ -50,7 +50,7 @@
     <module>hadoop-kafka</module>
     <module>hadoop-azure-datalake</module>
     <module>hadoop-aliyun</module>
-<!--    <module>hadoop-fs2img</module>-->
+    <module>hadoop-fs2img</module>
     <module>hadoop-benchmark</module>
   </modules>
 

--- a/hadoop-tools/pom.xml
+++ b/hadoop-tools/pom.xml
@@ -50,7 +50,7 @@
     <module>hadoop-kafka</module>
     <module>hadoop-azure-datalake</module>
     <module>hadoop-aliyun</module>
-    <module>hadoop-fs2img</module>
+<!--    <module>hadoop-fs2img</module>-->
     <module>hadoop-benchmark</module>
   </modules>
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

This PR introduces the following changes:

- Refactor `EncryptionAdapter` so that `computeKeys` is a private method and is called internally from the adapter instead of publicly (e.g., from `AbfsClient`). This also removes the need for storing the encoded key and sha strings (which are not destroyed anyway).
- Adds null checks in `EncryptionAdapter.destroy()`
- Ensures that the `EncryptionAdapter` object that is created in `AbfsClient. addEncryptionKeyRequestHeaders` is destroyed if it was created for an existing file, right after retrieving the key and sha
- Calls `destroy` on the encryption adapter in `AbfsInputStream.close()` and `AbfsOutputStream.close()`

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

